### PR TITLE
Add slope slide to player model

### DIFF
--- a/Assets/Scripts/FirstPersonController.cs
+++ b/Assets/Scripts/FirstPersonController.cs
@@ -8,6 +8,7 @@ public class FirstPersonController:MonoBehaviour {
     [SerializeField] private float walkSpeed = 3.0f;
     [SerializeField] private float runSpeed = 6.0f;
     [SerializeField] private float climbSpeed = 3.0f;
+    [SerializeField] private float slopeSlideSpeed = 8.0f;
 
     // Movement speed when the player is not moving forward.
     [SerializeField] private float slowSpeedWalk = 1.8f;
@@ -18,16 +19,32 @@ public class FirstPersonController:MonoBehaviour {
     [SerializeField] private float deceleration = 100f;
 
     [Header("Jumping Parameters")]
-    [SerializeField] private float gravity = 30f;
-    [SerializeField] private float jumpForce = 8f;
+    [SerializeField] private float gravity = 40f;
+    [SerializeField] private float jumpForce = 7.8f;
 
     [Header("Functional Options")]
     [SerializeField] private bool canJump = true;
     [SerializeField] private bool canRun = true;
+    [SerializeField] private bool willSlideOnSlope = true;
 
     [Header("Controls")]
     [SerializeField] private KeyCode jumpKey = KeyCode.Space;
     [SerializeField] private KeyCode runKey = KeyCode.LeftShift;
+
+    // Slope sliding parameters
+    private Vector3 hitPointNormal;
+    private bool IsSliding {
+        get {
+            // Check if characther is grounded and raycast hit a slope
+            if(characterController.isGrounded && Physics.Raycast(transform.position, Vector3.down, out RaycastHit slopeHit, 2f)) {
+                // Check if slope angle is greater than character controller's slope limit
+                hitPointNormal = slopeHit.normal;
+                return Vector3.Angle(hitPointNormal, Vector3.up) > characterController.slopeLimit;
+            } else {
+                return false;
+            }
+        }
+    }
 
     private Vector2 currentInput;
 
@@ -56,7 +73,7 @@ public class FirstPersonController:MonoBehaviour {
     /// </summary>
     private void HandleJump() {
         if(canJump) {
-            if(Input.GetKey(jumpKey) && characterController.isGrounded) {
+            if(Input.GetKey(jumpKey) && characterController.isGrounded && !IsSliding) {
                 moveDirection.y = jumpForce;
             }
         }
@@ -71,7 +88,7 @@ public class FirstPersonController:MonoBehaviour {
     /// </remarks>
     private void HandleInput() {
         // If the player is running, the walk speed is set to the run speed, otherwise it is set to the walk speed.
-        float baseSpeed = IsRunning ? runSpeed : walkSpeed;
+        float baseSpeed = IsRunning && !IsSliding ? runSpeed : walkSpeed;
         float speed = baseSpeed;
 
         float horizontalInput = Input.GetAxisRaw("Horizontal");
@@ -116,9 +133,16 @@ public class FirstPersonController:MonoBehaviour {
     /// Applies movement to player, depending on positional values
     /// </summary>
     private void ApplyFinalMovement() {
+        // Apply gravity
         if(!characterController.isGrounded) {
             moveDirection.y -= gravity * Time.deltaTime;
         }
+        // Apply slope sliding
+        if(willSlideOnSlope && IsSliding) {
+            moveDirection += new Vector3(hitPointNormal.x, -hitPointNormal.y, hitPointNormal.z) * slopeSlideSpeed;
+        }
+
+        // Move the character
         characterController.Move(moveDirection * Time.deltaTime);
     }
 

--- a/ProjectSettings/Packages/com.unity.probuilder/Settings.json
+++ b/ProjectSettings/Packages/com.unity.probuilder/Settings.json
@@ -29,7 +29,7 @@
             {
                 "type": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                 "key": "experimental.enabled",
-                "value": "{\"m_Value\":true}"
+                "value": "{\"m_Value\":false}"
             },
             {
                 "type": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",


### PR DESCRIPTION
Remove SphereCast and use Raycast for player model.

Still buggy, player does not slide all the way down due to raycast detecting ground before the player is on the ground.