### PR TITLE
Fix code bug

### DIFF
--- a/Assets/Scripts/Item Scripts/Door.cs
+++ b/Assets/Scripts/Item Scripts/Door.cs
@@ -68,7 +68,7 @@ public class Door:NetworkBehaviour, IInteractable {
 	}
 	public override void OnNetworkSpawn() {
 		if(IsHost)
-			code.Value = int.Parse(Random.Range(0, 10000).ToString("D4"));
+			code.Value = int.Parse(Random.Range(1000, 10000).ToString("D4"));
 		base.OnNetworkSpawn();
 	}
 


### PR DESCRIPTION
Move the range from 0 to 1000 for random code.

Since the first digit cannot be 0, approximately 9.9% of the possible codes are eliminated.